### PR TITLE
Replace forward slashes

### DIFF
--- a/src/render-and-download.js
+++ b/src/render-and-download.js
@@ -72,7 +72,7 @@ module.exports = function(issues, dest, callback) {
       var filename = sprintf(
         '#%0' + String(digit) + 'd-%s.html',
         issue.number,
-        issue.title.trim().replace(/\s+/g, '-'));
+        issue.title.trim().replace(/\s+|\//g, '-'));
       var filepath = path.join(dest, filename);
 
       return renderFile(path.resolve(__dirname, '../tmpl/issue.html'), issue)


### PR DESCRIPTION
Those cause trouble: either files are not downloaded at all or the process aborts with the error:

```
[INFO] gh-issue-export - Found image file, https://cloud.githubusercontent.com/assets/123456/1234567/12345678-9abc-def0-1234-56789abcdef0.png
ENOENT, open 'repo/#666-First-part/of-the-title-with-slash.html'
```

This patch replaces all slashes with dashes (`-`).
